### PR TITLE
Fix namespace get_cursor/deltas methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,15 +296,18 @@ save_to_db(last_cursor)
 ```
 
 ### Exclude changes from a specific type --- get only messages
+````ruby
 inbox.namespaces.first.deltas(cursor, exclude=[Inbox::Contact,
                                                Inbox::Event,
                                                Inbox::File,
                                                Inbox::Tag,
                                                Inbox::Thread]) do |event, object|
-if event == 'create' or event == 'modify"
+if event == 'create' or event == 'modify'
         puts object.subject
     end
 end
+```
+
 
 ### Handling Errors
 The Nilas API uses conventional HTTP response codes to indicate success or failure of an API request. The ruby gem raises these as native exceptions.

--- a/lib/namespace.rb
+++ b/lib/namespace.rb
@@ -61,7 +61,7 @@ module Inbox
 
     def get_cursor(timestamp)
       # Get the cursor corresponding to a specific timestamp.
-      path = @_api.url_for_path("n/#{@namespace_id}/delta/generate_cursor")
+      path = @_api.url_for_path("/n/#{@namespace_id}/delta/generate_cursor")
       data = { :start => timestamp }
 
       cursor = nil
@@ -71,7 +71,7 @@ module Inbox
         cursor = json["cursor"]
       end
 
-      return cursor
+      cursor
     end
 
     OBJECTS_TABLE = {
@@ -88,9 +88,10 @@ module Inbox
     }
 
     def deltas(cursor, exclude_types=[])
+      raise 'Please provide a block for receiving the delta objects' if !block_given?
       exclude_string = ""
 
-      if not exclude_types.empty?
+      if exclude_types.any?
         exclude_string = "&exclude_types="
 
         exclude_types.each do |value|
@@ -106,7 +107,7 @@ module Inbox
 
       # loop and yield deltas until we've come to the end.
       loop do
-        path = @_api.url_for_path("n/#{@namespace_id}/delta?cursor=#{cursor}#{exclude_string}")
+        path = @_api.url_for_path("/n/#{@namespace_id}/delta?cursor=#{cursor}#{exclude_string}")
         json = nil
 
         RestClient.get(path) do |response,request,result|

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -12,13 +12,13 @@ describe 'Delta sync API wrapper' do
     @namespace_id = 'nnnnnnn'
     @inbox = Inbox::API.new(@app_id, @app_secret, @access_token)
 
-    stub_request(:post, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nilas.comn/nnnnnnn/delta/generate_cursor").
+    stub_request(:post, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nilas.com/n/nnnnnnn/delta/generate_cursor").
          to_return(:status => 200, :body => File.read('spec/fixtures/initial_cursor.txt'), :headers => {})
 
-    stub_request(:get, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nilas.comn/nnnnnnn/delta?cursor=0").
+    stub_request(:get, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nilas.com/n/nnnnnnn/delta?cursor=0").
          to_return(:status => 200, :body => File.read('spec/fixtures/first_cursor.txt'), :headers => {'Content-Type' => 'application/json'})
 
-    stub_request(:get, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nilas.comn/nnnnnnn/delta?cursor=a9vtneydekzye7uwfumdd4iu3").
+    stub_request(:get, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nilas.com/n/nnnnnnn/delta?cursor=a9vtneydekzye7uwfumdd4iu3").
          to_return(:status => 200, :body => File.read('spec/fixtures/second_cursor.txt'), :headers => {})
 
   end


### PR DESCRIPTION
Both were just missing slashes in their URLs.

Didn't notice https://github.com/inboxapp/inbox-ruby/pull/16 until just opening this. I'll amend my commit once that is in.

Also (although this is out of the scope of this pull request), thoughts on somehow returning the last cursor/signaling that the account has no more deltas? There's currently no way to know what the best cursor is to use for next time `deltas` is invoked.